### PR TITLE
Fix: reqwest::blocking panic when called from async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokenizers",
+ "tokio",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-cpp",
@@ -2171,7 +2172,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["development-tools", "text-processing"]
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1.52.1", features = ["macros", "rt"] }
 
 [features]
 default = ["ts-rust"]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -165,25 +165,31 @@ fn mean_pool_normalize(data: &[f32], seq_len: usize, dim: usize, mask: &[f32]) -
 }
 
 fn download_model(model_name: &str, target_dir: &Path) -> Result<()> {
-    let base_url = format!("https://huggingface.co/{model_name}/resolve/main");
-
     let files = ["model.onnx", "tokenizer.json"];
 
-    for file in &files {
-        let url = format!("{base_url}/{file}");
-        let dest = target_dir.join(file);
+    let model_name_owned = model_name.to_string();
+    let target_dir_owned = target_dir.to_path_buf();
 
-        eprintln!("Downloading {url}...");
+    let handle = std::thread::spawn(move || -> Result<()> {
+        for file in &files {
+            let url = format!("https://huggingface.co/{model_name_owned}/resolve/main/{file}");
+            let dest = target_dir_owned.join(file);
 
-        let response = reqwest::blocking::get(&url)
-            .with_context(|| format!("HTTP request to {url}"))?
-            .error_for_status()
-            .context("HTTP request failed")?;
-        let buf = response.bytes().context("Reading response body")?;
-        std::fs::write(&dest, &buf).with_context(|| format!("Writing {}", dest.display()))?;
-    }
+            eprintln!("Downloading {url}...");
 
-    Ok(())
+            let response = reqwest::blocking::get(&url)
+                .with_context(|| format!("HTTP request to {url}"))?
+                .error_for_status()
+                .context("HTTP request failed")?;
+            let buf = response.bytes().context("Reading response body")?;
+            std::fs::write(&dest, &buf).with_context(|| format!("Writing {}", dest.display()))?;
+        }
+        Ok(())
+    });
+
+    handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("Model download thread panicked"))?
 }
 
 #[cfg(test)]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -189,7 +189,7 @@ fn download_model(model_name: &str, target_dir: &Path) -> Result<()> {
 
     handle
         .join()
-        .map_err(|_| anyhow::anyhow!("Model download thread panicked"))?
+        .map_err(|e| anyhow::anyhow!("Model download thread panicked: {e:?}"))?
 }
 
 #[cfg(test)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -572,6 +572,7 @@ fn extract_java_imports(content: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
     use tempfile::TempDir;
 
@@ -675,5 +676,28 @@ mod tests {
 
         let result2 = engine.search("second", 20, None).expect("search");
         assert!(result2.contains("b.rs"));
+    }
+
+    #[tokio::test]
+    async fn search_from_tokio_context_does_not_panic() {
+        let cache_temp = TempDir::new().expect("cache temp dir");
+        // SAFETY: This is an isolated test — mutating the env var is safe
+        // within this test's scope to force a unique cold model cache path.
+        unsafe { env::set_var("XDG_CACHE_HOME", cache_temp.path()) };
+
+        let temp = TempDir::new().expect("project temp dir");
+        fs::write(
+            temp.path().join("lib.rs"),
+            "fn search_engine() -> Vec<String> {\n    vec![\"hello\".to_string()]\n}\n",
+        )
+        .expect("write");
+
+        let engine = SearchEngine::new(temp.path().to_path_buf());
+        let result = engine.search("search_engine", 20, None);
+        assert!(
+            result.is_ok(),
+            "Search from tokio context should not panic: {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION
Closes #2

The `download_model` function uses `reqwest::blocking::get()` which panics when called from within a tokio async context. This PR isolates the blocking HTTP call by spawning a dedicated OS thread, preventing the nested-runtime conflict.

Implementation plan posted as a comment below.