### PR TITLE
Gate model download stdout behind optional callback

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use ort::session::Session;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
+
+pub type DownloadCallback = Arc<dyn Fn(&str) + Send + Sync>;
 
 const DEFAULT_MODEL_NAME: &str = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_DIMENSION: usize = 384;
@@ -12,6 +15,7 @@ pub struct Embedder {
     session: Option<Session>,
     tokenizer: Option<tokenizers::Tokenizer>,
     dimension: usize,
+    download_callback: Option<DownloadCallback>,
 }
 
 impl Embedder {
@@ -22,7 +26,17 @@ impl Embedder {
             session: None,
             tokenizer: None,
             dimension: DEFAULT_DIMENSION,
+            download_callback: None,
         }
+    }
+
+    pub fn with_download_callback(mut self, callback: DownloadCallback) -> Self {
+        self.download_callback = Some(callback);
+        self
+    }
+
+    pub fn set_download_callback(&mut self, callback: DownloadCallback) {
+        self.download_callback = Some(callback);
     }
 
     pub fn initialize(&mut self) -> Result<()> {
@@ -38,7 +52,7 @@ impl Embedder {
         let tokenizer_path = model_dir.join("tokenizer.json");
 
         if !onnx_path.exists() || !tokenizer_path.exists() {
-            download_model(&self.model_name, &model_dir)?;
+            download_model(&self.model_name, &model_dir, self.download_callback.clone())?;
         }
 
         let session = Session::builder()
@@ -164,7 +178,11 @@ fn mean_pool_normalize(data: &[f32], seq_len: usize, dim: usize, mask: &[f32]) -
     pooled
 }
 
-fn download_model(model_name: &str, target_dir: &Path) -> Result<()> {
+fn download_model(
+    model_name: &str,
+    target_dir: &Path,
+    callback: Option<DownloadCallback>,
+) -> Result<()> {
     let files = ["model.onnx", "tokenizer.json"];
 
     let model_name_owned = model_name.to_string();
@@ -175,7 +193,9 @@ fn download_model(model_name: &str, target_dir: &Path) -> Result<()> {
             let url = format!("https://huggingface.co/{model_name_owned}/resolve/main/{file}");
             let dest = target_dir_owned.join(file);
 
-            eprintln!("Downloading {url}...");
+            if let Some(ref cb) = callback {
+                cb(&url);
+            }
 
             let response = reqwest::blocking::get(&url)
                 .with_context(|| format!("HTTP request to {url}"))?

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 
 use super::chunker;
 use super::db::{SearchDb, StoredChunk};
-use super::embedder::Embedder;
+use super::embedder::{DownloadCallback, Embedder};
 use super::format::{SearchResult, format_results};
 use super::metrics;
 use super::query_classifier::classify_query;
@@ -20,6 +20,7 @@ const METRIC_CANDIDATE_LIMIT: usize = 1000;
 pub struct SearchEngine {
     project_root: PathBuf,
     embedder_cache_dir: PathBuf,
+    download_callback: Option<DownloadCallback>,
 }
 
 impl SearchEngine {
@@ -31,11 +32,25 @@ impl SearchEngine {
         Self {
             project_root,
             embedder_cache_dir,
+            download_callback: None,
         }
     }
 
+    pub fn with_download_callback(mut self, callback: DownloadCallback) -> Self {
+        self.download_callback = Some(callback);
+        self
+    }
+
+    pub fn set_download_callback(&mut self, callback: DownloadCallback) {
+        self.download_callback = Some(callback);
+    }
+
     fn get_embedder(&self) -> Embedder {
-        Embedder::new(self.embedder_cache_dir.clone())
+        let mut embedder = Embedder::new(self.embedder_cache_dir.clone());
+        if let Some(ref cb) = self.download_callback {
+            embedder.set_download_callback(cb.clone());
+        }
+        embedder
     }
 
     fn ensure_embedder(embedder: &mut Embedder) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod ts_chunker;
 mod vector_store;
 
 pub use db::StoredChunk;
+pub use embedder::DownloadCallback;
 pub use engine::SearchEngine;
 pub use format::{SearchResult, format_results};
 pub use query_classifier::QueryType;


### PR DESCRIPTION
## Problem

The embedder unconditionally printed the HuggingFace download URL to stderr via `eprintln!`. This pollutes TUI applications that consume the crate — any model download bleeds the raw URL into the terminal UI.

## Solution

Replace the hardcoded `eprintln!` with an optional `DownloadCallback`:

```rust
pub type DownloadCallback = Arc<dyn Fn(&str) + Send + Sync>;
```

Consumers can set it on either `Embedder` or `SearchEngine`:

```rust
let cb: DownloadCallback = Arc::new(|url| {
    my_tui_status.set_message(&format!("Downloading {url}..."));
});

let engine = SearchEngine::new(project_root)
    .with_download_callback(cb);
```

When no callback is configured (the default), downloads proceed silently with no stdout/stderr output.

## Changes

- `embedder`: Added `DownloadCallback` type alias (`Arc<dyn Fn(&str) + Send + Sync>`), optional field on `Embedder`, builder + mutable setters. `download_model` calls the callback if present instead of `eprintln!`.
- `engine`: `SearchEngine` gains the same optional callback, propagated to `Embedder` via `get_embedder()`.
- `lib`: Exports `DownloadCallback` for consumer use.
- Removed the sole `eprintln!` call.

## Testing

All 110 existing tests pass. `cargo clippy` and `cargo fmt` clean.