### PR TITLE
fix: snap UTF-8 truncation to char boundary (issue 7)

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -53,11 +53,7 @@ pub fn format_results(results: &[SearchResult]) -> String {
 
         let content_lines: Vec<&str> = r.chunk.content.lines().collect();
         for line in content_lines.iter().take(3) {
-            let trimmed = if line.len() > 120 {
-                format!("{}...", &line[..117])
-            } else {
-                line.to_string()
-            };
+            let trimmed = crate::util::truncate_with_ellipsis(line, 120);
             lines.push(format!("   {trimmed}"));
         }
         if content_lines.len() > 3 {
@@ -178,5 +174,15 @@ mod tests {
         let output = format_results(&[result]);
         assert!(!output.contains("pathMatch="));
         assert!(!output.contains("importGraph="));
+    }
+
+    #[test]
+    fn long_line_with_multibyte_char_does_not_panic() {
+        // Regression test for issue 7: U+2019 (3-byte char) near byte 117.
+        let prefix = "x".repeat(115);
+        let long_line = format!("{prefix}\u{2019}some more trailing text here");
+        let result = make_result("test.rs", 1, 1, "file", None, &long_line);
+        let output = format_results(&[result]);
+        assert!(output.contains("..."));
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -184,5 +184,9 @@ mod tests {
         let result = make_result("test.rs", 1, 1, "file", None, &long_line);
         let output = format_results(&[result]);
         assert!(output.contains("..."));
+        for line in output.lines() {
+            let content = line.trim_start();
+            assert!(content.len() <= 120, "preview line exceeded 120 bytes");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod ranker;
 mod scanner;
 mod text_chunker;
 mod ts_chunker;
+mod util;
 mod vector_store;
 
 pub use db::StoredChunk;

--- a/src/text_chunker.rs
+++ b/src/text_chunker.rs
@@ -535,11 +535,7 @@ fn extract_paragraph_name(content: &str) -> Option<String> {
     if first_line.is_empty() {
         return None;
     }
-    if first_line.len() <= 60 {
-        Some(first_line.to_string())
-    } else {
-        Some(format!("{}...", &first_line[..57]))
-    }
+    Some(crate::util::truncate_with_ellipsis(first_line, 60))
 }
 
 fn enforce_max_size(chunk: TextChunk) -> Vec<TextChunk> {
@@ -829,5 +825,18 @@ mod tests {
         let content = "[1, 2, 3]";
         let chunks = chunk_json(content, "arr.json");
         assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn extract_paragraph_name_multibyte_does_not_panic() {
+        // Regression: multi-byte char straddling the 57-byte cut in extract_paragraph_name.
+        let prefix = "a".repeat(56);
+        let content =
+            format!("{prefix}\u{2019}rest of a very long first line that exceeds sixty bytes");
+        let name = extract_paragraph_name(&content);
+        assert!(name.is_some());
+        let name = name.expect("should have name");
+        assert!(std::str::from_utf8(name.as_bytes()).is_ok());
+        assert!(name.len() <= 60);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,77 @@
+pub fn truncate_with_ellipsis(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    if max_bytes <= 3 {
+        let mut i = max_bytes;
+        while i > 0 && !s.is_char_boundary(i) {
+            i -= 1;
+        }
+        return s[..i].to_string();
+    }
+    let target = max_bytes - 3;
+    let mut i = target;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    format!("{}...", &s[..i])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_string_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 10), "hello");
+    }
+
+    #[test]
+    fn exact_length_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hello", 5), "hello");
+    }
+
+    #[test]
+    fn long_ascii_truncated() {
+        let s = "a".repeat(200);
+        let result = truncate_with_ellipsis(&s, 120);
+        assert_eq!(result.len(), 120);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn multibyte_at_cut_is_valid_utf8() {
+        // U+2019 RIGHT SINGLE QUOTATION MARK is 3 bytes: 0xE2 0x80 0x99
+        let prefix = "a".repeat(115);
+        let s = format!("{prefix}\u{2019}trailing text to make it long enough");
+        let result = truncate_with_ellipsis(&s, 120);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+        assert!(result.len() <= 120);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn emoji_at_cut_is_valid_utf8() {
+        // Emoji are 4 bytes
+        let prefix = "b".repeat(118);
+        let s = format!("{prefix}\u{1F600}more text here");
+        let result = truncate_with_ellipsis(&s, 120);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+        assert!(result.len() <= 120);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn max_bytes_less_than_or_equal_3_no_ellipsis() {
+        let s = "hello world";
+        let result = truncate_with_ellipsis(s, 2);
+        assert!(result.len() <= 2);
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn max_bytes_zero() {
+        let result = truncate_with_ellipsis("hello", 0);
+        assert_eq!(result, "");
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,13 +52,13 @@ mod tests {
 
     #[test]
     fn emoji_at_cut_is_valid_utf8() {
-        // Emoji are 4 bytes
-        let prefix = "b".repeat(118);
+        // U+1F600 is 4 bytes: F0 9F 98 80. Place it so target=117 lands inside.
+        // bytes 0..=115 = 'b', bytes 116..=119 = emoji. target=117 is a continuation
+        // byte; loop must walk back to 116 (boundary at start of emoji).
+        let prefix = "b".repeat(116);
         let s = format!("{prefix}\u{1F600}more text here");
         let result = truncate_with_ellipsis(&s, 120);
-        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
-        assert!(result.len() <= 120);
-        assert!(result.ends_with("..."));
+        assert_eq!(result, format!("{}...", "b".repeat(116)));
     }
 
     #[test]
@@ -67,6 +67,14 @@ mod tests {
         let result = truncate_with_ellipsis(s, 2);
         assert!(result.len() <= 2);
         assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn max_bytes_le_3_with_multibyte_walks_back_to_zero() {
+        // max_bytes=2 with a 3-byte leading char: byte 2 is a continuation byte,
+        // loop walks back to 0, returning "".
+        let result = truncate_with_ellipsis("\u{2019}hello", 2);
+        assert_eq!(result, "");
     }
 
     #[test]


### PR DESCRIPTION
Closes #7

Fix UTF-8 truncation panic in `format::format_results` and the same latent bug in `text_chunker::extract_paragraph_name`. Snap byte cuts to a valid char boundary via a small shared helper.

Implementation plan posted as a comment below.
